### PR TITLE
(.gitlab-ci.yml) Add OpenDingux target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/ctr-static-cmake.yml'
 
+  # OpenDingux
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/dingux-cmake.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -99,3 +103,12 @@ libretro-build-ctr:
   extends:
     - .libretro-ctr-static-cmake-retroarch-master
     - .core-defs
+
+# OpenDingux
+libretro-build-dingux-mips32:
+  extends:
+    - .libretro-dingux-cmake-mips32
+    - .core-defs
+  variables:
+    DINGUX_CFLAGS:   -fomit-frame-pointer -march=mips32 -mtune=mips32r2 -mhard-float
+    DINGUX_CXXFLAGS: -fomit-frame-pointer -march=mips32 -mtune=mips32r2 -mhard-float


### PR DESCRIPTION
This PR adds an OpenDingux target to the `.gitlab-ci.yml` file. Tested on an RG350M, the core is rather demanding and many games run slowly - but quite a few run full speed, including popular titles such as 8 BIT PANDA, STELE, CAULIFLOWER POWER, WITCHEM UP, REBOUND 2, WARM WHEELS, MASTER OF BLOCKS, BOKDOWN, etc.

(This was also an exercise in enabling OpenDingux `cmake` builds via the new infrastructure, something which had not been attempted before...)