### PR TITLE
webOS: fix for lstat64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -348,6 +348,4 @@ libretro-build-webos-armv7a:
     - .core-defs
   before_script:
     - !reference [.libretro-webos-cmake, before_script]
-    - export CFLAGS="-Os"
-    - echo 'set(CMAKE_C_FLAGS_RELEASE "-Os" CACHE STRING "" FORCE)' > build_flags.cmake
-    - export CORE_ARGS="${CORE_ARGS} -C ${CI_PROJECT_DIR}/build_flags.cmake"
+    - sed -i 's/lstat(/lstat64(/' "$CI_PROJECT_DIR/$CMAKE_SOURCE_ROOT/vendor/zip/src/zip.c"


### PR DESCRIPTION
Now that its building in the CI, here is the fix for the original compilation issue.

Due to supporting webOS 1 etc, we have a really old glibc version which means it still uses lstat64 not lstat like in modern glibc.

Its probably not necessary to do this however, as I doubt TIC80 files are > 2 GB but this removes this limitation and fixes the compiler.